### PR TITLE
重新实现 redis storage 策略

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,19 @@ const dispatcher = new Dispatcher({
   }
 });
 ```
+
+## Options
+
+### Dispatcher
+* `port` **Optional** `Number` port the server listened.
+* `storage` **Optional** `String` Dispatcher storage, it can be `memory` or `redis`, *storageOptions* is required if you use *redis*. default `memory`.
+* `storageOptions` **Optional** `Object` should be an object with *redis*(as a redis instance) property.
+* `timeout` **Optional** `Number` Dispatcher send timeout, default `1000` ms.
+
+### Worker
+* `handler` **Required** `Function` payload handler.
+* `dispatcherPort` **Optional** `Number` Dispatcher server port.
+* `dispatcherHost` **Optional** `String` Dispatcher server host.
+* `retryStrategy` **Optional** `Function` return the time(ms) retry connect to dispatcher.
+
+

--- a/examples/dispatcher_redis_test.js
+++ b/examples/dispatcher_redis_test.js
@@ -21,4 +21,4 @@ setInterval(function () {
   dispatcher.send(payload).then((res) => {
     console.log('send success: ', res);
   }).catch(console.error);
-}, 100);
+}, 1);

--- a/examples/worker_test.js
+++ b/examples/worker_test.js
@@ -23,4 +23,4 @@ setInterval(() => {
   if (task) {
     task.resolve(task.data);
   }
-}, 200);
+}, 4);

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -19,7 +19,7 @@ const defaultOptions = {
 };
 
 // default send msg timeout (ms)
-const DEFAULT_SEND_TIMEOUT = 5000; 
+const DEFAULT_SEND_TIMEOUT = 1000;
 
 const warning = 'Warning: tomqueue MemoryStorage is not\n'
   + 'designed for a production environment, as it will leak\n'
@@ -41,9 +41,11 @@ class Dispatcher extends Server {
     this.channels = new Storage(this.options.storageOptions);
     this.workers = {};
     this.healthyWorkers = {};
-    this.clientId = 1;
 
-    this.setMaxListeners(Number.MAX_VALUE);
+    // this object used to cache unReplied payload's
+    // transaction id and resolve object and reject object
+    this.uncommitedCache = {};
+    this.clientId = 1;
   }
 
   handleReply(reply, workerId) {
@@ -59,11 +61,22 @@ class Dispatcher extends Server {
     reply = utils.packObject(reply);
     this.channels.shift(reply.channel).then((task) => {
       debug('shift :', reply.channel);
-      if (reply.error) {
-        task && task.tId && this.emit('ack_err_' + task.tId, reply.error);
-      } else {
-        task && task.tId && this.emit('ack_' + task.tId, reply);
+      let hasTransactionId = false;
+
+      if (task && task.tId) {
+        hasTransactionId = true;
       }
+
+      if (reply.error) {
+        hasTransactionId && this.uncommitedCache[task.tId] &&
+          this.uncommitedCache[task.tId][1](reply.error);
+      } else {
+        hasTransactionId && this.uncommitedCache[task.tId] &&
+          this.uncommitedCache[task.tId][0](reply);
+      }
+
+      // remove current cache
+      hasTransactionId && delete this.uncommitedCache[task.tId];
 
       if (worker) {
         delete worker.channels[reply.channel];
@@ -74,7 +87,7 @@ class Dispatcher extends Server {
   }
 
   send(payload) {
-    const _this = this;
+    // const _this = this;
     const channel = payload.channel;
     if (!channel) {
       return Promise.reject('Missing "channel" property in payload');
@@ -88,31 +101,18 @@ class Dispatcher extends Server {
           this._dispatch(channel);
         }
 
-        function handleSendSuccess(data) {
-          cleanListeners(this.tId);
-          return resolve(data);
-        }
+        this.uncommitedCache[tId] = [resolve, reject, Date.now()];
 
-        function handleSendFail(err) {
-          cleanListeners(this.tId);
-          return reject(err);
-        }
+        // remove uncommited cache when touching timeout
+        // and retry dispatch payload
+        setTimeout(() => {
+          debug('[clean handler] check if transaction %s done => %s .', tId, !this.uncommitedCache[tId]);
+          this.uncommitedCache[tId] && delete this.uncommitedCache[tId];
 
-        function cleanListeners(tId) {
-          _this.removeListener('ack_' + tId, handleSendSuccess);
-          _this.removeListener('ack_err_' + tId, handleSendFail);
-        }
-
-        // handle success and fail event
-        this.on('ack_' + tId, handleSendSuccess.bind({ tId }));
-        this.on('ack_err_' + tId, handleSendFail.bind({ tId }));
-
-        // TODO: remove listener when touching timeout if needed
-        // setTimeout(() => {
-        //   debug('[clean hanndler] transaction => %s', tId);
-        //   this.removeListener('ack_' + tId, handleSendSuccess);
-        //   this.removeListener('ack_err_' + tId, handleSendFail);
-        // }, DEFAULT_SEND_TIMEOUT);
+          // TODO: max retry option
+          // resend payload
+          this._dispatch(channel);
+        }, this.options.timeout || DEFAULT_SEND_TIMEOUT);
       });
     });
   }


### PR DESCRIPTION
使用cache暂时缓存未提交事务的`resolve` `reject` 方法，等待接收到 worker 反馈后，将缓存中 `resolve` `reject` 方法取出，改变promise状态。